### PR TITLE
No margins on QL printers!

### DIFF
--- a/printer/Brother-QL-500.xml
+++ b/printer/Brother-QL-500.xml
@@ -34,10 +34,10 @@ USA
     <margins>
       <general>
         <unit>mm</unit>
-        <top>3</top>
-        <bottom>3</bottom>
-        <left>1.5</left>
-        <right>1.5</right>
+        <top>0</top>
+        <bottom>0.03333</bottom>
+        <left>0</left>
+        <right>0</right>
       </general>
     </margins>
     <consumables>

--- a/printer/Brother-QL-550.xml
+++ b/printer/Brother-QL-550.xml
@@ -34,10 +34,10 @@ USA
     <margins>
       <general>
         <unit>mm</unit>
-        <top>3</top>
-        <bottom>3</bottom>
-        <left>1.5</left>
-        <right>1.5</right>
+        <top>0</top>
+        <bottom>0.03333</bottom>
+        <left>0</left>
+        <right>0</right>
       </general>
     </margins>
     <consumables>

--- a/printer/Brother-QL-570.xml
+++ b/printer/Brother-QL-570.xml
@@ -34,10 +34,10 @@ USA
     <margins>
       <general>
         <unit>mm</unit>
-        <top>3</top>
-        <bottom>3</bottom>
-        <left>1.5</left>
-        <right>1.5</right>
+        <top>0</top>
+        <bottom>0.0333</bottom>
+        <left>0</left>
+        <right>0</right>
       </general>
     </margins>
     <consumables>

--- a/printer/Brother-QL-650TD.xml
+++ b/printer/Brother-QL-650TD.xml
@@ -34,10 +34,10 @@ USA
     <margins>
       <general>
         <unit>mm</unit>
-        <top>3</top>
-        <bottom>3</bottom>
-        <left>1.5</left>
-        <right>1.5</right>
+        <top>0</top>
+        <bottom>0.03333</bottom>
+        <left>0</left>
+        <right>0</right>
       </general>
     </margins>
     <consumables>


### PR DESCRIPTION
These label printers can print right to the edge. Setting a non-zero hardware margin, let alone one that wastes 10% of a label, does not make sense.
The last row tends to get lost, thus I used a 1-point bottom margin.