### PR TITLE
RFC: add PT-9700PC

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -63,7 +63,8 @@ PRINTERS			= printer/Brother-QL-500.xml \
 				  printer/Brother-PT-9200PC.xml \
 				  printer/Brother-PT-9400.xml \
 				  printer/Brother-PT-9500PC.xml \
-				  printer/Brother-PT-9600.xml
+				  printer/Brother-PT-9600.xml \
+				  printer/Brother-PT-9700PC.xml
 OPTIONS				= opt/Brother-PTQL-Align.xml \
 				  opt/Brother-PTQL-AutoCut.xml \
 				  opt/Brother-PTQL-ChainPrinting.xml \

--- a/printer/Brother-PT-9700PC.xml
+++ b/printer/Brother-PT-9700PC.xml
@@ -1,0 +1,79 @@
+<!--
+Copyright (c) 2006  Arne John Glenstrup <panic@itu.dk>
+
+This file is part of ptouch-driver.
+
+ptouch-driver is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or (at
+your option) any later version.
+
+ptouch-driver is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with ptouch-driver; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+USA
+-->
+<printer id="printer/Brother-PT-9700PC">
+  <make>Brother</make>
+  <model>PT-9700PC</model>
+  <pcmodel>BR950P</pcmodel>
+  <mechanism>
+    <thermal/>
+    <!--not "color"-->
+    <resolution>
+      <dpi>
+        <x>360</x>
+        <y>720</y>
+      </dpi>
+    </resolution>
+  </mechanism>
+  <url>https://support.brother.com/g/b/producttop.aspx?c=us_ot&amp;lang=en&amp;prod=9700eus</url>
+  <lang>
+    <proprietary />
+  </lang>
+  <autodetect>
+    <general>
+      <ieee1284>MFG:Brother;CMD:PT-CBP;MDL:PT-9700PC;CLS:PRINTER;</ieee1284>
+      <commandset>PT-CBP</commandset>
+      <description>Brother PT-9700PC</description>
+      <manufacturer>Brother</manufacturer>
+      <model>PT-9700PC</model>
+    </general>
+  </autodetect>
+  <functionality>D</functionality>
+  <driver>ptouch-pt</driver>
+  <unverified/>
+  <!--no "contrib_url"-->
+  <comments>
+    <en>
+      Prints 40mm per second
+    </en>
+  </comments>
+  <select>
+    <option id="opt/Brother-PTQL-Resolution">
+      <arg_defval>ev/360dpi</arg_defval>
+      <enum_val id="ev/360dpi" />
+      <enum_val id="ev/360x720dpi" />
+    </option>
+    <option id='opt/Brother-PT-LegacyHires' />
+    <option id="opt/Brother-PTQL-BytesPerLine">
+      <enum_val id="ev/48" />
+    </option>
+    <option id="opt/Brother-PT-PageSize">
+      <arg_defval>ev/tz-36</arg_defval>
+      <enum_val id="ev/tz-4" />
+      <enum_val id="ev/tz-6" />
+      <enum_val id="ev/tz-9" />
+      <enum_val id="ev/tz-12" />
+      <enum_val id="ev/tz-18" />
+      <enum_val id="ev/tz-24" />
+      <enum_val id="ev/tz-36" />
+    </option>
+    <option id="opt/Brother-PT-HalfCut" />
+  </select>
+</printer>

--- a/rastertoptch.c
+++ b/rastertoptch.c
@@ -225,6 +225,8 @@
  * <tr><td>PT-9500PC<td>auto/half<td>RLE<td>360<br>
                                         360x720<td>384<td>48<td>TZ,AV6-36mm
  * <tr><td>PT-9600  <td>auto/half<td>RLE<td>360<td>384<td>48<td>TZ,AV6-36mm
+ * <tr><td>PT-9700PC<td>auto/half<td>RLE<td>360<br>
+                                        360x720<td>384<td>48<td>TZ4-36mm
  * </table>
  *
  * <h2>Tape characteristics</h2>


### PR DESCRIPTION
This makes autodetection by the OS work correctly for me, but doesn't actually fix
36mm printing. (see https://github.com/philpem/printer-driver-ptouch/issues/3

Modifications from the 9500PC were to remove the opt/Brother-PT-LegacyTransferMode
setting, as according to the escape command manual from brother, this
printer uses the "new" style.

Signed-off-by: Karl Palsson <karlp@tweak.net.au>