### PR TITLE
Add support for P-touch QL-560

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,6 +35,7 @@ DRIVERS				= driver/ptouch-pt.xml \
 				  driver/ptouch-ql.xml
 PRINTERS			= printer/Brother-QL-500.xml \
 				  printer/Brother-QL-550.xml \
+				  printer/Brother-QL-560.xml \
 				  printer/Brother-QL-570.xml \
 				  printer/Brother-QL-650TD.xml \
 				  printer/Brother-QL-800.xml \

--- a/printer/Brother-QL-560.xml
+++ b/printer/Brother-QL-560.xml
@@ -1,0 +1,70 @@
+<!--
+Copyright (c) 2006  Arne John Glenstrup <panic@itu.dk>
+
+This file is part of ptouch-driver.
+
+ptouch-driver is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or (at
+your option) any later version.
+
+ptouch-driver is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with ptouch-driver; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+USA
+-->
+<printer id="printer/Brother-QL-560">
+  <make>Brother</make>
+  <model>QL-560</model>
+  <pcmodel>BRQ560</pcmodel>
+  <mechanism>
+    <thermal/>
+    <!--not "color"-->
+    <resolution>
+      <dpi>
+        <x>300</x>
+        <y>300</y>
+      </dpi>
+    </resolution>
+  </mechanism>
+  <url>http://www.brother.co.uk/cms.cfm/s_page/55570/s_level/17510/s_product/QL560</url>
+  <lang>
+    <proprietary />
+  </lang>
+  <autodetect>
+    <general>
+      <ieee1284>MFG:Brother;CMD:PT-CBP;MDL:QL-560;CLS:PRINTER;</ieee1284>
+      <commandset>PT-CBP</commandset>
+      <description>Brother QL-560</description>
+      <manufacturer>Brother</manufacturer>
+      <model>QL-560</model>
+    </general>
+  </autodetect>
+  <functionality>B</functionality>
+  <driver>ptouch-ql</driver>
+  <unverified />
+  <!--no "contrib_url"-->
+  <comments>
+    <en>
+    Prints 3 inches per second.
+    </en>
+  </comments>
+  <select>
+    <option id="opt/Brother-PTQL-Resolution">
+      <enum_val id="ev/300dpi" />
+    </option>
+    <option id="opt/Brother-PTQL-BytesPerLine">
+      <enum_val id="ev/90" />
+    </option>
+    <option id="opt/Brother-PTQL-PixelTransfer">
+      <enum_val id="ev/RLE" sense="false" />
+      <enum_val id="ev/ULP" />
+    </option>
+    <option id="opt/Brother-PTQL-AutoCut" />
+  </select>
+</printer>


### PR DESCRIPTION
Added support for QL-560 by editing the files for the QL-570 and QL-500 to fit the properties of the 560.
Tested via USB. Printing works, however it seems like the printer always prints 100mm length labels in continuous mode. Is this expected or is there something I can do about this?
Trying to use the Maintenance option `Print Self Test Page` and the printer options `Query Printer for Default Options` both result in the printer entering an error state (Power LED blinking fast and non-stop).